### PR TITLE
Interface cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Erik Boesen
+Copyright (c) 2017 FRC Team 1418
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Application for FRC scouting. Written using [Electron](http://electron.atom.io/)
 
 Get the newest compiled version [here](https://github.com/frc1418/VictiScout/releases)!
 
-Download the server counterpart (not necessary, but pretty cool) of this app [here](https://github.com/frc1418/VictiScout-Server)!
-
 ![Screenshot](screenshot.png)
 
 ## Development dependencies
@@ -29,8 +27,11 @@ If you'd like to only package for one OS, append `-mac`, `-win`, or `-linux` to 
 
 See [here](https://github.com/electron-userland/electron-packager#readme) for an explanation of how to modify your packaging settings.
 
-## Author
-This software was written by [Erik Boesen](https://github.com/ErikBoesen), originally for [Team 1418](https://github.com/frc1418).
+## Authors
+This software was originally written by [Erik Boesen](https://github.com/ErikBoesen), for [Team 1418](https://github.com/frc1418). It's since been expanded on by the following authors:
+* [Adrian Hall](https://github.com/aderhall)
+* [Tate Ward](https://github.com/MoonMoon2)
+* [Tim Winters](https://github.com/Twinters007)
 
 ## License
 This software is licensed under the MIT license. More information in [`LICENSE`](LICENSE).

--- a/index.html
+++ b/index.html
@@ -11,16 +11,6 @@
     <div class="row">
         <input type="number" id="team" placeholder="Team #" class="large">
         <input type="number" id="match" placeholder="Match #" class="large">
-        <p>Playoffs<input type="checkbox" id="playoffs"></p>
-        <input type="text" id="notes" placeholder="Notes" class="large">
-    </div>
-    <div class="row">
-      <select class="special" id="target">
-          <option>Save data locally</option>
-          <option>Submit data to server</option>
-      </select>
-    </div>
-    <div class="row">
         <h2 id="path-label">Save location:</h2>
         <input id="path" class="special large" type="text">
         <p id="path-warning">INVALID DIRECTORY</p>
@@ -29,16 +19,15 @@
         <button id="view">View Data</button>
     </div>
     <div class="row">
-        <div>
-            <h1>AUTO</h1>
-        </div>
+        <h1>AUTO</h1>
         <div>
             <h2>AUTO Gear Delivery</h2>
             <button class="decrease">-</button>
             <input type="number" id="auto-gear-count" value="0" min="0">
             <button class="increase">+</button>
         </div>
-        <div>
+        <!-- TODO: Maybe re-add this; it's been totally useless and seldom used so far. -->
+        <!--<div>
             <h2>Which Gear Slot?</h2>
             <select id="auto-gear-slot">
                 <option>None</option>
@@ -46,9 +35,7 @@
                 <option>Right</option>
                 <option>Left</option>
             </select>
-        </div>
-    </div>
-    <div class="row">
+        </div>-->
         <div>
             <h2>AUTO Low Boiler</h2>
             <button class="decrease">-</button>
@@ -61,12 +48,13 @@
             <input type="number" id="auto-high-boiler" value="0" min="0">
             <button class="increase">+</button>
         </div>
-        <div>
+        <!-- We don't care about misses for now. -->
+        <!--<div>
             <h2>AUTO High Boiler Misses</h2>
             <button class="decrease">-</button>
             <input type="number" id="auto-high-boiler-misses" value="0" min="0">
             <button class="increase">+</button>
-        </div>
+        </div>-->
     </div>
     <div class="row">
         <h1>TELEOP</h1>
@@ -82,54 +70,30 @@
             <input type="number" id="high-boiler" value="0" min="0">
             <button class="increase">+</button>
         </div>
-        <div>
+        <!--<div>
             <h2>High Boiler Misses</h2>
             <button class="decrease">-</button>
             <input type="number" id="high-boiler-misses" value="0" min="0">
             <button class="increase">+</button>
-        </div>
-        <div>
-            <h2>Steam</h2>
-
-        </div>
-    </div>
-    <div class="row">
-        <!--Gears, Rope Climb, High Boiler Accuracy-->
-        <!-- Rope Climb and High Boiler Accuracy in Auto and Tele need to be added -->
+        </div>-->
         <div class="tasks">
             <h2>Gears Delivered</h2>
-            <img src="img/gear.svg">
             <button class="decrease">-</button>
             <input type="number" id="gear" value="0" min="0">
             <button class="increase">+</button>
         </div>
         <div class="tasks">
-            <h2>Rope Climb</h2>
-            <img src="img/ropeclimb.svg" id="ropeImage" onclick="ropeImage.onclick();">
-            <!-- TODO: Re-add attempted? -->
-            <p>Achieved? <input type="checkbox" id="rope-achieved" onclick="ropeChanged();"></p>
-        </div>
-        <div class="tasks">
-            <h2>High Boiler Accuracy (Auto)</h2>
-            <input type="text" id="auto-accuracy" value="0%" class="percent">
-            <button id="calculate-accuracy">Calculate</button>
-            <h2>High Boiler Accuracy (Teleop)</h2>
-            <input type="text" id="teleop-accuracy" value="0%" class="percent">
-            <button id="teleop-calculate-accuracy">Calculate</button>
-            <h2>Steam Output</h2>
-            <input type="text" id="steam-counter" value="0 kPa" class="steam">
-            <button id="steam">Calculate</button>
-        </div>
-        <div class="tasks">
-            <h2>Total Points:</h2>
-            <button id="calculate-total">Calculate</button>
-            <h3>Match Points</h3>
-            <input type="number" id="total-points">
-            <h3>Ranking Points</h3>
-            <input type="number" id="ranking-points">
+            <h2>Climbed?</h2>
+            <select id="climbed">
+                <option>No</option>
+                <option>Attempted</option>
+                <option>Yes</option>
+            </select>
         </div>
     </div>
-
+    <div class="row">
+        <textarea id="notes" placeholder="Write notes here..."></textarea>
+    </div>
 
     <script src="script.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -13,8 +13,8 @@ let mainWindow;
 function createWindow() {
 	// Create the browser window.
 	mainWindow = new BrowserWindow({
-		width: 600,
-		height: 550
+		width: 900,
+		height: 475
 	});
 
 	// and load the index.html of the app.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/frc1418/VictiScout#readme",
   "devDependencies": {
     "electron-packager": "^7.3.0",
-    "electron": "^1.2.0",
-    "unirest": "^0.5.0"
+    "electron": "^1.2.0"
   }
 }

--- a/renderData.js
+++ b/renderData.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const unirest = require('unirest');
 
 // Define <thead> and <tbody> vars to be filled later on.
 var thead = document.getElementsByTagName('thead')[0],
@@ -7,22 +6,14 @@ var thead = document.getElementsByTagName('thead')[0],
 
 console.log(localStorage.target);
 
-if (localStorage.target === 'Save data locally') {
-	// Fetch (string type) contents of data.json.
-	var values = fs.readFileSync(localStorage.path + '/data.json') + '';
+// Fetch (string type) contents of data.json.
+var values = fs.readFileSync(localStorage.path + '/data.json') + '';
 
-	// Split up the single long string into an array of strings. One string = one object = one submission of data.
-	values = values.split('\n');
+// Split up the single long string into an array of strings. One string = one object = one submission of data.
+values = values.split('\n');
 
-    render(values);
-} else {
-	unirest.get('http://' + localStorage.path + ':8080/api/data').end(function(response) {
-		var values = response.body;
-        values = values.split('\n');
+render(values);
 
-        render(values);
-	});
-}
 function render(data) {
     // Go through data array and turn string data into a manipulable JSON object
     for (i = 0; i < data.length - 1; i++) {

--- a/script.js
+++ b/script.js
@@ -2,269 +2,123 @@
 const fs = require('fs');
 // ipc is used to open and communicate with the data viewer and other additional windows.
 const ipc = require('electron').ipcRenderer;
-const unirest = require('unirest');
-// Define prominent buttons.
-var elements = {
+// Define some elements.
+var pg = {
     match: document.getElementById('match'),
-    target: document.getElementById('target'),
     submit: document.getElementById('submit'),
-    steam: document.getElementById('steam'),
-	  reset: document.getElementById('reset'),
-	  view: document.getElementById('view'),
+    reset: document.getElementById('reset'),
+    view: document.getElementById('view'),
     pathLabel: document.getElementById('path-label'),
-	  path: document.getElementById('path'),
-    autoAccuracy: document.getElementById('calculate-accuracy'),
-    teleopAccuracy: document.getElementById('teleop-calculate-accuracy'),
-    total: document.getElementById('calculate-total'),
-	  pathWarning: document.getElementById('path-warning'),
-    ropeAchieved: document.getElementById('rope-achieved'),
-    ropeImage: document.getElementById('ropeImage')}
+    path: document.getElementById('path'),
+    pathWarning: document.getElementById('path-warning')
+}
+
 // Begin the data/ submit processing stuff
 // Get path to Desktop based on OS.
-elements.path.value = (process.platform == 'win32') ? process.env.USERPROFILE + '\\Desktop' : process.env.HOME + '/Desktop';
+pg.path.value = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+
 // Generate an array of all <input>s (plus <select>s) in document.
 // These will be used to generate an object.
 // Inputs named .special are exempt. These are used for things like path selection.
-var tags = document.querySelectorAll('input:not(.special), select:not(.special)');
+var tags = document.querySelectorAll('input:not(.special), select:not(.special), textarea');
 // Create empty object.
 var inputs = {};
 // Make each element be the value to a key named after its ID.
 for (i = 0; i < tags.length; i++) inputs[tags[i].id] = tags[i];
 // Submit data (also resets all fields).
-elements.submit.onclick = function() {
-	// Make empty data object
-	var data = {};
-	// Go through each input in the data object and fill in the data from it
-	for (var input in inputs) {
-		// Input the values from each input into the data object.
-		// Need to get different data depending on the type of the input.
-		switch (inputs[input].type) {
-			case 'checkbox':
-				// Set this data point to a boolean of whether or not the checkbox is checked
-				data[input] = inputs[input].checked;
-				break;
-			case 'number':
-				// Make this data point be the parsed integer value of that input
-				data[input] = parseInt(inputs[input].value);
-				break;
-			default:
-				// Just use the raw string data
-				data[input] = inputs[input].value;
-				break;
-		}
-	}
-
-	// Add timestamp to data.
-	data['timestamp'] = new Date().getTime();
-
-	// Log gathered data to console, useful for debug
-	// console.log(data);
-
-	// TODO: Define this at the top
-	if (target.value === 'Save data locally') {
-		// Append new JSON-parsed data to data.json file in designated location (usually Desktop).
-		fs.appendFile(elements.path.value + '/data.json', JSON.stringify(data) + '\n', function(err) {
-			// If data cannot be placed in file in this location
-			if (err) {
-				// Show the INVALID DIRECTORY warning
-				elements.pathWarning.style.display = 'inline-block';
-				// Focus cursor into directory
-				elements.path.focus();
-			} else { // If data export goes ok
-				// Hide INVALID DIRECTORY warning
-				elements.pathWarning.style.display = 'none';
-				// Reset <input>s to prepare for new contents after submission
-				resetInputs();
-			}
-		});
-	} else {
-        console.log(data);
-        // Upload data to server via a POST request.
-		unirest.post('http://' + elements.pathLabel.value + ':8080/api/data')
-            .send(data)
-			.end(function(response) {
-				console.log(response.body);
-			});
-        // Reset <input>s to prepare for new contents after submission
-        resetInputs();
-	}
-};
-elements.target.onchange = function() {
-    if (elements.target.value === 'Save data locally') {
-        elements.pathLabel.innerHTML = 'Save location:';
-        // TODO: Following line is a duplicate of the one at the top of the doc, fix
-        elements.path.value = (process.platform == 'win32') ? process.env.USERPROFILE + '\\Desktop' : process.env.HOME + '/Desktop';
-    } else {
-        elements.pathLabel.innerHTML = 'Server IP:';
-        elements.path.value = '192.168.1.1';
+pg.submit.onclick = function() {
+    // Make empty data object
+    var data = {};
+    // Go through each input in the data object and fill in the data from it
+    for (var input in inputs) {
+        // Input the values from each input into the data object.
+        // Need to get different data depending on the type of the input.
+        switch (inputs[input].type) {
+            case 'checkbox':
+                // Set this data point to a boolean of whether or not the checkbox is checked
+                data[input] = inputs[input].checked;
+                break;
+            case 'number':
+                // Make this data point be the parsed integer value of that input
+                data[input] = parseInt(inputs[input].value);
+                break;
+            default:
+                // Just use the raw string data
+                data[input] = inputs[input].value;
+                break;
+        }
     }
+
+    // Add timestamp to data.
+    // data['timestamp'] = new Date().getTime();
+
+    // Log gathered data to console, useful for debug
+    // console.log(data);
+
+    // Append new JSON-parsed data to data.json file in designated location (usually Desktop).
+    fs.appendFile(pg.path.value + '/data.json', JSON.stringify(data) + '\n', function(err) {
+        // If data cannot be placed in file in this location
+        if (err) {
+            // Show the INVALID DIRECTORY warning
+            pg.pathWarning.style.display = 'inline-block';
+            // Focus cursor into directory
+            pg.path.focus();
+        } else { // If data export goes ok
+            // Hide INVALID DIRECTORY warning
+            pg.pathWarning.style.display = 'none';
+            // Reset <input>s to prepare for new contents after submission
+            resetInputs();
+        }
+    });
 };
 // When the value of the path input changes, check the path's validity just like above.
 // This is the exact same thing as above, except without resetting values.
 // TODO: Combine these.
-elements.path.onchange = function() {
-    if (elements.target.value === 'Save data locally')
-	fs.access(elements.path.value, function(err) {
-		if (err) {
-			elements.pathWarning.style.display = 'inline-block';
-			elements.path.focus();
-		} else {
-			elements.pathWarning.style.display = 'none';
-		}
-	});
+pg.path.onchange = function() {
+    if (pg.target.value === 'Save data locally')
+        fs.access(pg.path.value, function(err) {
+            if (err) {
+                pg.pathWarning.style.display = 'inline-block';
+                pg.path.focus();
+            } else {
+                pg.pathWarning.style.display = 'none';
+            }
+        });
 };
 // When reset button is clicked, trigger reset
 // TODO: call this function directly
-elements.reset.onclick = function() { resetInputs(); }
+pg.reset.onclick = function() {
+    resetInputs();
+}
 // Reset all fields without submitting any data.
 function resetInputs() {
-  // Save the current match. It'll later be increased by one and reset.
-  currentMatch = parseInt(elements.match.value);
-  elements.ropeImage.src = 'img/ropeclimb.svg'
-	// For each input, reset to default value.
-	for (var input in inputs) {
-		// Reset to different values depending on what type of input it is
-		if (inputs[input].type === 'number' && inputs[input].className !== 'large') { // If it's a small number box
-			inputs[input].value = 0;
-		} else if (inputs[input].className === 'large') { // If it's a big textbox (like team number)
-			inputs[input].value = '';
-		} else if (inputs[input].type === 'checkbox') { // Checkbox
-			inputs[input].checked = false;
-		} else if (inputs[input].tagName === 'SELECT') { // Selector
-			inputs[input].value = 'No';
-		}
-	}
+    // Save the current match. It'll later be increased by one and reset.
+    // TODO: This triggers a warning if the input is empty.
+    currentMatch = parseInt(pg.match.value);
+    // For each input, reset to default value.
+    for (var input in inputs) {
+        // Reset to different values depending on what type of input it is
+        if (inputs[input].type === 'number' && inputs[input].className !== 'large') inputs[input].value = 0; // If it's a small number box
+        else if (inputs[input].className === 'large') inputs[input].value = ''; // If it's a big textbox (like team number)
+        else if (inputs[input].type === 'checkbox') inputs[input].checked = false; // Checkbox
+        else if (inputs[input].tagName === 'SELECT') inputs[input].value = 'No'; // Selector
+    }
     // Reset match field to be one greater than it was previously.
     // TODO: Only do this when 'submit' button is clicked?
-    elements.match.value = currentMatch + 1;
-	console.log('Reset all inputs.');
+    pg.match.value = currentMatch + 1;
+    console.log('Reset all inputs.');
 }
 // When 'View Data' button is clicked
-elements.view.onclick = function() {
-	// Store the path to the data docuent
-	localStorage.path = elements.path.value;
-  localStorage.target = target.value;
-	// Tell main.js to open rendered data window
-	ipc.send('renderData');
+pg.view.onclick = function() {
+    // Store the path to the data docuent
+    localStorage.path = pg.path.value;
+    // Tell main.js to open rendered data window
+    ipc.send('renderData');
 };
-
-// Begin the score processing stuff
-// Function for determining accuracy in autonomous
-elements.autoAccuracy.onclick = function() {
-    var autoMisses = +document.getElementById('auto-high-boiler-misses').value;
-    var accuracy = +document.getElementById('auto-high-boiler').value;
-    var autoCombined = autoMisses + accuracy;
-    if (autoCombined != 0) {
-      var autoAccuracy = accuracy/autoCombined;
-    } else {
-      var autoAccuracy = 0;
-    }
-    autoAccuracy = Math.round(autoAccuracy * 100) + '%';
-    document.getElementById('auto-accuracy').value = autoAccuracy;
-}
-// Function for determining accuracy in teleop
-elements.teleopAccuracy.onclick = function() {
-    var teleopMisses = +document.getElementById('high-boiler-misses').value;
-    var teleopScores = +document.getElementById('high-boiler').value;
-    var teleopCombined = teleopMisses + teleopScores;
-    if (teleopCombined != 0) {
-      var teleopAccuracy = teleopScores/teleopCombined;
-    } else {
-      var teleopAccuracy = 0;
-    }
-    teleopAccuracy = Math.round(teleopAccuracy * 100) + '%';
-    document.getElementById('teleop-accuracy').value = teleopAccuracy;
-}
-// Change the image color and the checkbox value
-elements.ropeImage.onclick = function() {
-    //If the image is red, make it white, if it is white, make it red
-    if (elements.ropeImage.src.endsWith('img/ropeclimb.svg')) {
-        elements.ropeAchieved.checked=true;
-        elements.ropeImage.src = 'img/ropeclimb-red.svg';
-    } else {
-        elements.ropeAchieved.checked=false;
-        elements.ropeImage.src = 'img/ropeclimb.svg';
-    }
-}
-// Link the checkbox onchange function (called in the document) to the image onclick
-ropeChanged = function() { elements.ropeImage.onclick(); };
-var rotorCalc = function(autoGears, teleGears, playoffs) {
-  // Get total gears
-  gears = autoGears + teleGears;
-  // Calculate number of rotors turning by the end of auto period and calculate points from them
-  var autoRotors = (autoGears > 13) ? 4 : Math.round(Math.sqrt(autoGears));
-  var autoPoints = 60*autoRotors;
-  // Calculate rotors turning by the end of teleop;
-  // then get rotors activated DURING teleop and get points
-  var rotors = (gears > 13) ? 4 : Math.round(Math.sqrt(gears));
-  var teleopRotors = rotors-autoRotors;
-  var teleopPoints = 40*teleopRotors;
-  // You get a bonus from turning all 4 rotors: 100 points in playoffs or 1 RP in quals
-  var rotorsBonus = (playoffs&&rotors===4) ? 100 : 0;
-  var rankingBonus = (!playoffs&&rotors===4) ? 1 : 0;
-  // Tally up points
-  var totalPoints = teleopPoints+autoPoints+rotorsBonus;
-  // Return the values as an object
-  return {points: {total: totalPoints, auto: autoPoints, teleop: teleopPoints}, rotors: {total: rotors, auto: autoRotors, teleop: teleopRotors}, rankingPoints: rankingBonus}
-}
-// Totals up all points for the whole thing
-elements.total.onclick = function() {
-    // Call accuracy functions
-    elements.autoAccuracy.onclick();
-    elements.teleopAccuracy.onclick();
-    // Call steam function
-    var steamPoints = elements.steam.onclick();
-    // Get gear values for auto and teleop
-    var teleGears = +document.getElementById('gear').value;
-    var autoGears = +document.getElementById('auto-gear-count').value;
-    // The score depends on the game stage: in the playoffs, no ranking points are scored;
-    // In the qualifiers, only ranking points are scored (the match points still matter
-    // as wins/ties win ranking points)
-    var playoffs = document.getElementById('playoffs').checked;
-    // You get a ranking point from scoring 40kPa in auto, but in playoffs you get 20 points
-    var steamBonus = (steamPoints>40&&playoffs) ? 20 : 0;
-    // Call the rotorCalc function to calculate points (and ranking points) from gears
-    var rotorInfo = rotorCalc(autoGears, teleGears, playoffs);
-    // We only need the points right now
-    var rotorPoints = rotorInfo.points.total;
-    // Check if the rope was climbed
-    var ropeClimbed = elements.ropeAchieved.checked;
-    // Calculate points from the rope climb
-    var ropePoints = (ropeClimbed) ? 50 : 0;
-    // Tally up all the points
-    var totalPoints = steamPoints + rotorPoints + ropePoints + steamBonus;
-    // Get ranking point values from the rotors and steam bonuses
-    var rankingPoints = rotorInfo.rankingPoints + ((steamPoints>40&&!playoffs) ? 1 : 0);
-    // Display the values for ranking points and total points
-    document.getElementById('ranking-points').value = rankingPoints;
-    document.getElementById('total-points').value = totalPoints;
-}
-// Calculate the steam produced (equivalent to 1 match point)
-elements.steam.onclick = function() {
-  // Get values of boiler scores
-  var autoLowBoiler = document.getElementById('auto-low-boiler').value;
-  var autoHighBoiler = document.getElementById('auto-high-boiler').value;
-  var highBoiler = document.getElementById('high-boiler').value;
-  var lowBoiler = document.getElementById('low-boiler').value;
-  // The number of steam points
-  var steamNum = 0;
-  // Point values for the gears
-  var pointKeys = {auto: {highBoiler: 1, lowBoiler: 3}, teleop: {highBoiler: 3, lowBoiler: 9}};
-  // Increment steamNum based on point values
-  steamNum += (lowBoiler-(lowBoiler%pointKeys.teleop.lowBoiler))/pointKeys.teleop.lowBoiler;
-  steamNum += (highBoiler-(highBoiler%pointKeys.teleop.highBoiler))/pointKeys.teleop.highBoiler;
-  steamNum += (autoLowBoiler-(autoLowBoiler%pointKeys.auto.lowBoiler))/pointKeys.auto.lowBoiler;
-  steamNum += (autoHighBoiler-(autoHighBoiler%pointKeys.auto.highBoiler))/pointKeys.auto.highBoiler;
-  // Display the value in the steam output element (with kPa appended)
-  steamNumText = steamNum + ' kPa';
-  document.getElementById('steam-counter').value = steamNumText;
-  // We can reuse this function for calculating totals
-  return steamNum;
-}
 // When user clicks on the screen, check if they clicked on an increase/decrease button
 onclick = function(e) {
-	// If click was on a decrease button > decrease the value of the adjacent input (but only if it's over 0)
-	if (e.target.className === 'decrease' && e.target.nextElementSibling.value > 0) e.target.nextElementSibling.value = parseInt(e.target.nextElementSibling.value) - 1;
-	// If click was on an increase button > increase the value of the adjacent input
-	if (e.target.className === 'increase') e.target.previousElementSibling.value = parseInt(e.target.previousElementSibling.value) + 1;
+    // If click was on a decrease button > decrease the value of the adjacent input (but only if it's over 0)
+    if (e.target.className === 'decrease' && e.target.nextpgibling.value > 0) e.target.nextpgibling.value = parseInt(e.target.nextpgibling.value) - 1;
+    // If click was on an increase button > increase the value of the adjacent input
+    if (e.target.className === 'increase') e.target.previouspgibling.value = parseInt(e.target.previouspgibling.value) + 1;
 };

--- a/style.css
+++ b/style.css
@@ -8,10 +8,13 @@
 body {
     background: #333;
     margin: 3px;
+    margin-top: 8px;
+    margin-bottom: 0;
     overflow: scroll;
 }
 input[type="number"],
 input[type="text"],
+textarea,
 button {
     border: none;
     background: #444;
@@ -48,9 +51,6 @@ button:active {
     height: 120px;
     margin-bottom: 10px;
 }
-#ropeImage {
-  height: 125px;
-}
 .row:first-of-type {
     padding: 0;
 }
@@ -60,10 +60,9 @@ button:active {
 .row input {
     width: 50px;
 }
-.row:nth-of-type(4),
-.row:nth-of-type(5) {
+.row:nth-of-type(2) {
+    margin-top: 10px;
     background: #555;
-    padding: 10px 0;
 }
 h1 {
     font-weight: bold;
@@ -96,4 +95,8 @@ option {
 #path-warning {
     color: red;
     display: none;
+}
+#notes {
+    width: 100%;
+    height: 250px;
 }


### PR DESCRIPTION
This is the first of three (or possibly more) PRs over the next couple of days. This one focuses more on the front-end of the application, and includes the following changes:
* Scrap accuracy calculators which are rarely used and take up a great deal of space and whose data we don't use (although the calculations are pretty impressive and could be helpful for certain types of analysis, they are rarely helpful in this context). (#23)
* Move the notes to the bottom and make them take up around half the screen; size is adjustable vertically (#24)
* Window is no longer squeezed into a square shape. (#25)
* Remove images of rope and gear. (#30)
* Get rid of playoffs checkbox since we seldom scout then this year anyway. (#31)

As I mentioned above, I'm planning three pull requests:
* Front end revamp (this one) to fix the above.
* Back end revamp to fix shoddy data management, window management, etc. (#26 #27 #28? #29 #32)
* Full translation into TypeScript (#16)