### PR TITLE
Removed Ugly Scrolls

### DIFF
--- a/data.css
+++ b/data.css
@@ -29,6 +29,6 @@ th {
 }
 td {
     white-space: nowrap;
-    overflow: scroll;
+    overflow: auto;
     max-width: 100px;
 }


### PR DESCRIPTION
If you change the ```overflow``` element to ```auto``` it only shows up when it needs to. Now it looks a lot better