### PR TITLE
Fix inability to modify packaged directories in Finder on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "package-mac": "electron-packager . --platform=darwin --icon=images/logo/logo.icns --arch=all --out dist/",
+    "package-mac": "electron-packager . --platform=darwin --icon=images/logo/logo.icns --arch=all --out dist/ --tmpdir=false",
     "package-linux": "electron-packager . --platform=linux --icon=images/logo/logo.png --arch=all --out dist/",
     "package-win": "electron-packager . --platform=win32 --icon=images/logo/logo.ico --arch=all --out dist/"
   },


### PR DESCRIPTION
It's impossible on Macs to delete the directories created in `dist/` through Finder. This is described in #73 and the issue was reported in electron-userland/electron-packager#375. The root cause was explained in jprichardson/node-fs-extra#492. I've done a workaround here.

NOTE: This actually causes another issue... so don't merge yet.